### PR TITLE
Fixes for perf-tool agent

### DIFF
--- a/perf-tool/include/serverClients.hpp
+++ b/perf-tool/include/serverClients.hpp
@@ -39,6 +39,7 @@ public:
     static constexpr int POLL_INTERVALS = 250;
     static constexpr int COMMAND_INTERVALS = 500;
     static constexpr int BUFFER_SIZE = 512;
+    static constexpr int DEFAULT_PORT = 9002;
 };
 
 class NetworkClient

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -36,13 +36,14 @@
 #include "objectalloc.hpp"
 #include "server.hpp"
 #include "exception.hpp"
+#include "serverClients.hpp"
 
 using json = nlohmann::json;
 
 jvmtiEnv *jvmti;
 
 /* Server arguments with defaults */
-int portNo = 9002;
+int portNo = ServerConstants::DEFAULT_PORT;
 std::string commandsPath = "";
 std::string logPath = "logs.json";
 

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -49,46 +49,43 @@ std::string logPath = "logs.json";
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
 {
-    std::string token;
     std::string optionsDelim = ",";
     std::string pathDelim = ":";
-    std::string oIn = (std::string)options;
+    std::string oIn(options);
     int pos1, pos2 = 0;
 
-    /* there is a max of two options the user can supply here
+    /* there is a max of three options the user can supply here
      * "commands" is followed by a path to the commands file
      * "log" is followed by the path to the location for the log file
      * "portno" is followed by a number indicating the port to run the server on 
      */
     while ((pos1 = oIn.find(optionsDelim)) != std::string::npos)
     {
-        if (pos1 != std::string::npos)
+        std::string token = oIn.substr(0, pos1);
+        if ((pos2 = token.find(pathDelim)) != std::string::npos)
         {
-            token = oIn.substr(0, pos1);
-            if ((pos2 = token.find(pathDelim)) != std::string::npos)
+            if (!token.substr(0, pos2).compare("commandFile"))
             {
-                if (!token.substr(0, pos2).compare("commandFile"))
-                {
-                    token.erase(0, pos2 + pathDelim.length());
-                    commandsPath = token;
-                }
-                else if (!token.substr(0, pos2).compare("logFile"))
-                {
-                    token.erase(0, pos2 + pathDelim.length());
-                    logPath = token;
-                }
-                else if (!token.substr(0, pos2).compare("portNo"))
-                {
-                    token.erase(0, pos2 + pathDelim.length());
-                    portNo = stoi(token);
-                }
+                fprintf(stderr, "commandFile\n");
+                token.erase(0, pos2 + pathDelim.length());
+                commandsPath = token;
             }
-            oIn.erase(0, pos1 + optionsDelim.length());
+            else if (!token.substr(0, pos2).compare("logFile"))
+            {
+                token.erase(0, pos2 + pathDelim.length());
+                logPath = token;
+            }
+            else if (!token.substr(0, pos2).compare("portNo"))
+            {
+                token.erase(0, pos2 + pathDelim.length());
+                portNo = stoi(token);
+            }
         }
+        oIn.erase(0, pos1 + optionsDelim.length());
     }
     if (!oIn.empty())
     {
-        token = oIn;
+        std::string token = oIn;
         if ((pos2 = token.find(pathDelim)) != std::string::npos)
         {
             if (!token.substr(0, pos2).compare("commandFile"))

--- a/perf-tool/src/client.cpp
+++ b/perf-tool/src/client.cpp
@@ -29,7 +29,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
-
+#include "serverClients.hpp"
 #include "utils.hpp"
 
 #define POLL_INTERVAL 150
@@ -166,7 +166,7 @@ void Client::closeClient()
 int main(int argc, char const *argv[])
 {
     string hostname = "localhost";
-    int portno = 9003;
+    int portno = ServerConstants::DEFAULT_PORT;
 
     if (argc > 2)
     {


### PR DESCRIPTION
1. Use the same default port number for both server and client
2. Small cleanup for option processing
3. Add critical section for updating map with number of contention samples per object type

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>