### PR TITLE
Add improvements to monitor contention functionality

### DIFF
--- a/perf-tool/include/monitor.hpp
+++ b/perf-tool/include/monitor.hpp
@@ -32,5 +32,5 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv,
 
 void setMonitorStackTrace(bool val);
 void setMonitorSampleRate(int rate);
-
+void setMonitorStackTraceDepth(int stackTraceDepth);
 #endif /* MONITOR_H_ */


### PR DESCRIPTION
Added new command option: "stackTraceDepth": N
If the value of the stackTraceDepth is larger than 0
the agent will collect N frames starting with the
method where monitor contention was detected.
Also, changed the behavior so that for a sample rate M
larger than 1 the agent will report only the M-th sample.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>