### PR TITLE
Implement app callback feature

### DIFF
--- a/perf-tool/include/infra.hpp
+++ b/perf-tool/include/infra.hpp
@@ -23,10 +23,14 @@
 #ifndef INFRA_H_
 #define INFRA_H_
 
+#include <algorithm>
+#include <mutex>
 #include <string>
 #include <jvmti.h>
+
 class Server;
 extern Server *server;
+extern JNIEnv *jni_env;
 
 void check_jvmti_error_throw(jvmtiEnv *jvmti, jvmtiError errnum, const char *str);
 
@@ -42,6 +46,38 @@ void sendToServer(std::string message);
 extern int portNo;
 extern std::string commandsPath;
 extern std::string logPath;
+
+class EventConfig
+{
+public:
+    struct CallbackIDs 
+    {
+        jclass cachedCallbackClass = NULL;
+        jmethodID cachedCallbackMethodId = NULL;
+    };
+private:
+    int sampleRate = 1;
+    int stackTraceDepth = 0;
+    std::string callbackClass;
+    std::string callbackMethod;
+    std::string callbackSignature;
+    CallbackIDs callbackIDs;
+    std::mutex configMutex;
+    #define MAX_TRACE_DEPTH 128
+public:
+    static constexpr int getMaxTraceDepth() { return MAX_TRACE_DEPTH; } 
+    int getSampleRate(void) const { return sampleRate; }
+    void setSampleRate(int rate) { sampleRate = (rate > 0 ? rate : 1); }
+    int getStackTraceDepth() const { return stackTraceDepth; }
+    void setStackTraceDepth(int depth) { stackTraceDepth = std::min(depth, MAX_TRACE_DEPTH); }
+    const std::string& getCallbackClass() const { return callbackClass; }
+    const std::string& getCallbackMethod() const { return callbackMethod; }
+    const std::string &getCallbackSignature() const { return callbackSignature; }
+    void setCallbacks(const std::string& cls, const std::string& method, const std::string& sig);
+    jclass getCachedCallbackClass() const { return callbackIDs.cachedCallbackClass; }
+    jmethodID getCachedCallbackMethodId() const { return callbackIDs.cachedCallbackMethodId; }
+    CallbackIDs getCallBackIDs(JNIEnv *env);
+};
 
 
 #endif /* INFRA_H_ */

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -41,6 +41,7 @@
 using json = nlohmann::json;
 
 jvmtiEnv *jvmti = NULL;
+JNIEnv *jni_env = NULL;
 
 /* Server arguments with defaults
  * These will be set by parseAgentOptions
@@ -148,7 +149,6 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM* vm, char *options, void *reserved)
             fprintf(stderr, "Cannot get JVMTI env\n");
             return rc;
         }
-        JNIEnv *jni_env;
         rc = vm->GetEnv((void **)&jni_env, JNI_VERSION_1_8);
         if (rc != JNI_OK)
         {


### PR DESCRIPTION
This commit gives the application the ability to register a
callback function with the agent, such that when an event is
triggered and data collected, that data is sent to the application
through the callback.
To accomodate this change the structure of a command changed
to allow the "callback" keyword, which will define the class,
method name and signature of the callback.
Example:
  {
    "functionality": "monitorEvents",
    "command": "start",
    "callback": {
      "class": "T",
      "method": "callback",
      "signature": "(Ljava/lang/String;)V"
    }
  }
The commit also implements some code restructuring to introduce
a `class EventConfig` which will be used to store (and cache)
information about each type of event that is monitored.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>