### PR TITLE
perf-tools: make timestamps nanosecond granular

### DIFF
--- a/perf-tool/src/serverClients.cpp
+++ b/perf-tool/src/serverClients.cpp
@@ -97,7 +97,7 @@ void LoggingClient::logData(const string message, const std::string receivedFrom
     {
         json log;
         auto currentClockTime = std::chrono::system_clock::now();
-        std::time_t currentTime = std::chrono::system_clock::to_time_t(currentClockTime);
+	long long int nano = std::chrono::duration_cast<std::chrono::nanoseconds>(currentClockTime.time_since_epoch()).count();
         
         /* If message was a proper json, log as formatted json
          * otherwise log the string as it is
@@ -112,7 +112,7 @@ void LoggingClient::logData(const string message, const std::string receivedFrom
         }
         
         log["from"] = receivedFrom;
-        log["timestamp"] = currentTime;
+        log["timestamp"] = nano;
         logFile << log.dump(2, ' ', true) << ',' << endl;
     }
 }


### PR DESCRIPTION
The current timestamp employed in the data has
second's granularity, which can be too restrictive
in many cases - for example in a high contention
case, many sections may be seen as having the same
timestamp. Convert time into nanosecond precision.

before:
  "timestamp": 1608336000
after:
  "timestamp": 1614073053488102314

Fixes: https://github.com/eclipse/openj9-utils/issues/19

Signed-off-by: Gireesh Punathil gpunathi@in.ibm.com