### PR TITLE
add a head field with object hashcode

### DIFF
--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -46,6 +46,15 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv, JNIEnv *env, 
     if (numSamples % monitorConfig.getSampleRate() != 0)
         return;
 
+    jvmtiError err;
+    jint hash;
+    err = jvmtiEnv->GetObjectHashCode(object, &hash);
+    if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve object hashcode.")) {
+	    char str[32];
+	    sprintf(str, "0x%x", hash);
+	    j["monitorHash"] = str;
+    }
+
     static std::map<std::string, int> numContentions;
     jclass cls = env->GetObjectClass(object);
     /* First get the class object */


### PR DESCRIPTION
When an app is profiled over a time period,
a number of sections are produced, potentially
for the same lock. However, there is no key
field in the JSON data that help us to associate
those together.

Add a "head" field with the hashcode of the object
which is the current subject of contention. According
to the JVMTI spec, the hashcode is guarenteed to be
unique throughout its life span.

From the doc:
```
jvmtiError
GetObjectHashCode(jvmtiEnv* env,
            jobject object,
            jint* hash_code_ptr)
For the object indicated by object, return via hash_code_ptr a hash code. 
This hash code could be used to maintain a hash table of object references, 
however, on some implementations this can cause significant performance
impacts--in most cases tags will be a more efficient means of associating
information with objects. This function guarantees the same hash code
value for a particular object throughout its life
```
Fixes: https://github.com/eclipse/openj9-utils/issues/22

Signed-off-by: Gireesh Punathil gpunathi@in.ibm.com