### PR TITLE
add event types

### DIFF
--- a/perf-tool/include/infra.hpp
+++ b/perf-tool/include/infra.hpp
@@ -44,7 +44,7 @@ JNIEXPORT void JNICALL VMInit(jvmtiEnv *jvmtiEnv, JNIEnv* jni_env, jthread threa
 JNIEXPORT void JNICALL VMDeath(jvmtiEnv *jvmtiEnv, JNIEnv* jni_env);
 jthread createNewThread(JNIEnv* jni_env);
 void JNICALL startServer(jvmtiEnv * jvmti, JNIEnv* jni, void *p);
-void sendToServer(std::string message);
+void sendToServer(std::string message, std::string event);
 
 extern int portNo;
 extern std::string commandsPath;

--- a/perf-tool/include/server.hpp
+++ b/perf-tool/include/server.hpp
@@ -67,7 +67,7 @@ public:
     void handleServer(void);
 
     /* Handle the message queue, and sends to all clients */
-    void handleMessagingClients(std::string message);
+    void handleMessagingClients(std::string message, std::string event);
 
     /* Closes all open files, connectend socketfd, and then the server's socket */
     void shutDownServer(void);

--- a/perf-tool/include/serverClients.hpp
+++ b/perf-tool/include/serverClients.hpp
@@ -110,7 +110,7 @@ public:
     LoggingClient(const std::string filename);
 
     void closeFile(void);
-    void logData(const std::string data, const std::string receivedFrom);
+    void logData(const std::string data, std::string event, const std::string receivedFrom);
 };
 
 #endif

--- a/perf-tool/src/exception.cpp
+++ b/perf-tool/src/exception.cpp
@@ -181,5 +181,5 @@ JNIEXPORT void JNICALL Exception(jvmtiEnv *jvmtiEnv,
         }
     }
 
-    sendToServer(jdata.dump());
+    sendToServer(jdata.dump(), "exceptionEvent");
 }

--- a/perf-tool/src/infra.cpp
+++ b/perf-tool/src/infra.cpp
@@ -248,9 +248,9 @@ void JNICALL startServer(jvmtiEnv * jvmti, JNIEnv* jni, void *p)
     server->handleServer();
 }
 
-void sendToServer(const std::string message)
+void sendToServer(const std::string message, std::string event)
 {
-    server->handleMessagingClients(message);
+    server->handleMessagingClients(message, event);
 }
 
 JNIEXPORT void JNICALL VMInit(jvmtiEnv *jvmtiEnv, JNIEnv* jni_env, jthread thread) {

--- a/perf-tool/src/methodEntry.cpp
+++ b/perf-tool/src/methodEntry.cpp
@@ -91,7 +91,7 @@ JNIEXPORT void JNICALL MethodEntry(jvmtiEnv *jvmtiEnv,
         }
     
         std::string s = j.dump();
-        sendToServer(s);
+        sendToServer(s, "methodEntryEvent");
     }
     mEntrySampleCount = atomic_fetch_add(&mEntrySampleCount, 1);
 }

--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -164,7 +164,7 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv, JNIEnv *env, 
         }
     }
     
-    sendToServer(j.dump());
+    sendToServer(j.dump(), "monitorContendedEnteredEvent");
 
     /* Also call the callback */
     
@@ -326,6 +326,9 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
             j["OwnerThread"] = jOwner;
         }
     }
+
+    sendToServer(j.dump(), "monitorContendedEnterEvent");
+
     json jCurrent;
     /* Get StackTrace */
     monitorConfig.getStackTrace(jvmtiEnv, thread, jCurrent, stackTraceDepth);

--- a/perf-tool/src/objectalloc.cpp
+++ b/perf-tool/src/objectalloc.cpp
@@ -157,6 +157,6 @@ JNIEXPORT void JNICALL VMObjectAlloc(jvmtiEnv *jvmtiEnv,
     json j;
     j["object"] = jObj; 
     std::string s = j.dump(2, ' ', true);
-    sendToServer(s);
+    sendToServer(s, "objectAllocationEvent");
 
 }

--- a/perf-tool/src/perf.cpp
+++ b/perf-tool/src/perf.cpp
@@ -135,7 +135,7 @@ void perfProcess(pid_t processID, int recordTime) {
             perfData["record"] = lineStr.c_str();
             idCount++;
 
-            sendToServer(perfData.dump());
+            sendToServer(perfData.dump(), "perfEvent");
         }
 
     }

--- a/perf-tool/src/server.cpp
+++ b/perf-tool/src/server.cpp
@@ -60,7 +60,7 @@ Server::Server(int portNo, const string &commandFileName, const string &logFileN
     }
 
     loggingClient = new LoggingClient(logFileName);
-    loggingClient->logData("Server started", "Server");
+    loggingClient->logData("Server started", "serverStartEvent", "Server");
 }
 
 void Server::handleServer()
@@ -232,7 +232,7 @@ void Server::handleClientCommand(string command, string from)
         std::cerr << "Improper command received from: " << from << '\n';
     }
 
-    loggingClient->logData(command, from);
+    loggingClient->logData(command, "commandDigestEvent", from);
 }
 
 void Server::sendMessage(const int socketFd, const string message)
@@ -254,7 +254,7 @@ void Server::sendMessage(const int socketFd, const string message)
     }
 }
 
-void Server::handleMessagingClients(string message)
+void Server::handleMessagingClients(string message, std::string event)
 {
 
     for (int i = 0; i < activeNetworkClients; i++)
@@ -262,7 +262,7 @@ void Server::handleMessagingClients(string message)
         int clientSocketFd = networkClients[i]->getSocketFd();
         sendMessage(clientSocketFd, message);
     }
-    loggingClient->logData(message, "Server");
+    loggingClient->logData(message, event, "Server");
 }
 
 void Server::startPerfThread(int time)
@@ -284,7 +284,7 @@ void Server::shutDownServer()
         perfThread.join();
     }
 
-    handleMessagingClients("Server shutting down");
+    handleMessagingClients("Server shutting down", "");
 
     /* close off commands, logs, and network client sockets */
     for (int i = 0; i < activeNetworkClients; i++)

--- a/perf-tool/src/serverClients.cpp
+++ b/perf-tool/src/serverClients.cpp
@@ -92,7 +92,7 @@ void LoggingClient::closeFile(void)
     }
 }
 
-void LoggingClient::logData(const string message, const std::string receivedFrom)
+void LoggingClient::logData(const string message, std::string event, const std::string receivedFrom)
 {
     if (logFile.is_open())
     {
@@ -113,6 +113,7 @@ void LoggingClient::logData(const string message, const std::string receivedFrom
         }
         
         log["from"] = receivedFrom;
+        log["eventType"] = event;
         log["timestamp"] = nano;
         logFile << log.dump(2, ' ', true) << ',' << endl;
     }

--- a/perf-tool/src/verboseLog.cpp
+++ b/perf-tool/src/verboseLog.cpp
@@ -85,7 +85,7 @@ jvmtiError verboseSubscriberCallback(jvmtiEnv *jvmti_env, const char *record, jl
     if (verboseSampleCount % verboseSampleRate == 0)
     {
         string s = string(record);
-        sendToServer(s);
+        sendToServer(s, "verboseGCEvent");
     }
 
     verboseSampleCount++;
@@ -96,5 +96,5 @@ jvmtiError verboseSubscriberCallback(jvmtiEnv *jvmti_env, const char *record, jl
 void verboseAlarmCallback(jvmtiEnv *jvmti_env, void *subscription_id, void *user_data)
 {
     string s = string("ERROR subscriber returned error");
-    sendToServer(s);
+    sendToServer(s, "verboseAlarmEvent");
 }


### PR DESCRIPTION
In the generated output of the perf-tool,
there can be many sections based on the input
configuration. Even though each sections have
different set of key-valus from which the section
can be identified, it is desirable to have an
eventType key, for easy consumption.

I have covered all the handlers implemented so far.

Fixes: https://github.com/eclipse/openj9-utils/issues/35

Signed-off-by: Gireesh Punathil <gpunathi@in.ibm.com>