### PR TITLE
Added MonitorContendedEnter event

### DIFF
--- a/perf-tool/include/infra.hpp
+++ b/perf-tool/include/infra.hpp
@@ -27,6 +27,9 @@
 #include <mutex>
 #include <string>
 #include <jvmti.h>
+#include "json.hpp"
+
+using json = nlohmann::json;
 
 class Server;
 extern Server *server;
@@ -78,6 +81,7 @@ public:
     const std::string& getCallbackMethod() const { return callbackMethod; }
     const std::string &getCallbackSignature() const { return callbackSignature; }
     void setCallbacks(const std::string& cls, const std::string& method, const std::string& sig);
+    void getStackTrace(jvmtiEnv *jvmtiEnv, jthread thread, json& j, jint StackTraceDepth);
     jclass getCachedCallbackClass() const { return callbackIDs.cachedCallbackClass; }
     jmethodID getCachedCallbackMethodId() const { return callbackIDs.cachedCallbackMethodId; }
     CallbackIDs getCallBackIDs(JNIEnv *env);

--- a/perf-tool/include/monitor.hpp
+++ b/perf-tool/include/monitor.hpp
@@ -29,6 +29,10 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv,
             JNIEnv* env,
             jthread thread,
             jobject object);
+JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv,
+            JNIEnv* env,
+            jthread thread,
+            jobject object);
 
 void setMonitorStackTrace(bool val);
 void setMonitorSampleRate(int rate);

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -122,6 +122,7 @@ jvmtiError setCallbacks(jvmtiEnv *jvmti)
     callbacks.VMInit = &VMInit;
     callbacks.VMDeath = &VMDeath;
     callbacks.VMObjectAlloc = &VMObjectAlloc;
+    callbacks.MonitorContendedEnter = &MonitorContendedEnter;
     callbacks.MonitorContendedEntered = &MonitorContendedEntered;
     callbacks.MethodEntry = &MethodEntry;
     callbacks.Exception = &Exception;

--- a/perf-tool/src/agentOptions.cpp
+++ b/perf-tool/src/agentOptions.cpp
@@ -74,23 +74,28 @@ void modifyMonitorEvents(const std::string& function, const std::string& command
     memset(&capa, 0, sizeof(jvmtiCapabilities));
     error = jvmti->GetCapabilities(&capa);
     check_jvmti_error(jvmti, error, "Unable to get current capabilties.");
-    if (capa.can_generate_monitor_events)
+    if (capa.can_generate_monitor_events && capa.can_get_monitor_info)
     {
         if (!command.compare("stop"))
         {
             memset(&capa, 0, sizeof(jvmtiCapabilities));
             capa.can_generate_monitor_events = 1;
+            capa.can_get_monitor_info = 1;
 
             error = jvmti->RelinquishCapabilities(&capa);
             check_jvmti_error(jvmti, error, "Unable to relinquish Monitor Events Capability.");
             error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
             check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEntered event.");
+            error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, (jthread)NULL);
+            check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEnter event.");
         }
         else if (!command.compare("start"))
         { 
             printf("Monitor Events Capability already enabled\n");
             error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
             check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEntered event notifications.");
+            error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, (jthread)NULL);
+            check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEnter event notifications.");
         } else {
             invalidCommand(function, command);
         }
@@ -101,16 +106,22 @@ void modifyMonitorEvents(const std::string& function, const std::string& command
         {
             memset(&capa, 0, sizeof(jvmtiCapabilities));
             capa.can_generate_monitor_events = 1;
+            capa.can_get_monitor_info = 1;
+
 
             error = jvmti->AddCapabilities(&capa);
             check_jvmti_error(jvmti, error, "Unable to init Monitor Events capability.");
 
+            error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, (jthread)NULL);
+            check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEnter event notifications.");
             error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
             check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEntered event notifications.");
         }
         else if (!command.compare("stop"))
         { 
             printf("Monitor Events Capability already disabled.");
+            error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, (jthread)NULL);
+            check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEnter event.");
             error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
             check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEntered event.");
         } else {

--- a/perf-tool/src/agentOptions.cpp
+++ b/perf-tool/src/agentOptions.cpp
@@ -100,6 +100,9 @@ void modifyMonitorEvents(const std::string& function, const std::string& command
     {
         error = jvmti->GetCapabilities(&capa);
         check_jvmti_error(jvmti, error, "Unable to get current capabilties.");
+        memset(&capa, 0, sizeof(jvmtiCapabilities));
+        capa.can_generate_monitor_events = 1;
+        capa.can_get_monitor_info = 1;
         error = jvmti->RelinquishCapabilities(&capa);
         check_jvmti_error(jvmti, error, "Unable to relinquish Monitor Events Capability.");
         error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);

--- a/perf-tool/src/agentOptions.cpp
+++ b/perf-tool/src/agentOptions.cpp
@@ -98,8 +98,6 @@ void modifyMonitorEvents(const std::string& function, const std::string& command
     }
     else if (!command.compare("stop"))
     {
-        error = jvmti->GetCapabilities(&capa);
-        check_jvmti_error(jvmti, error, "Unable to get current capabilties.");
         memset(&capa, 0, sizeof(jvmtiCapabilities));
         capa.can_generate_monitor_events = 1;
         capa.can_get_monitor_info = 1;

--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -214,3 +214,302 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv, JNIEnv *env, 
         }
     }
 }
+JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jthread thread, jobject object){
+    json j;
+    jvmtiError error;
+    
+    /* Get number of events and increment */
+    int numSamples = atomic_fetch_add(&monitorSampleCount, 1);
+    if (numSamples % monitorConfig.getSampleRate() != 0)
+        return;
+
+    jvmtiError err;
+    jint hash;
+    err = jvmtiEnv->GetObjectHashCode(object, &hash);
+    if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve object hashcode.")) 
+    {
+        char str[32];
+        sprintf(str, "0x%x", hash);
+        j["monitorHash"] = str;
+    }
+
+    static std::map<std::string, int> numContentions;
+    jclass cls = env->GetObjectClass(object);
+    /* First get the class object */
+    jmethodID mid = env->GetMethodID(cls, "getClass", "()Ljava/lang/Class;");
+    jobject clsObj = env->CallObjectMethod(object, mid);
+    /* Now get the class object's class descriptor */
+    cls = env->GetObjectClass(clsObj);
+    /* Find the getName() method on the class object */
+    mid = env->GetMethodID(cls, "getName", "()Ljava/lang/String;");
+    /* Call the getName() to get a jstring object back */
+    jstring strObj = (jstring)env->CallObjectMethod(clsObj, mid);
+    /* Now get the c string from the java jstring object */
+    const char *str = env->GetStringUTFChars(strObj, NULL);
+    /* record calling class */
+    j["class"] = str;
+
+    /* free str */
+    static std::mutex contentionMutex;
+    int samplesPerObjectType = 0;
+    {
+    std::lock_guard<std::mutex> lg(contentionMutex);
+    samplesPerObjectType = ++(numContentions[std::string(str)]);
+    }
+    j["numTypeContentions"] = samplesPerObjectType;
+    /* Release the memory pinned char array */
+    env->ReleaseStringUTFChars(strObj, str);
+    env->DeleteLocalRef(cls);
+
+    jvmtiMonitorUsage monitor_usage;
+    error = jvmtiEnv->GetObjectMonitorUsage(object, &monitor_usage);
+    if (check_jvmti_error(jvmtiEnv, error, "Unable to get Monitor usage info."))
+    {
+        error = jvmtiEnv->Deallocate((unsigned char *)(monitor_usage.waiters));
+        check_jvmti_error(jvmtiEnv, error, "Unable to deallocate waiters.\n");
+        error =  jvmtiEnv->Deallocate((unsigned char *)(monitor_usage.notify_waiters));
+        check_jvmti_error(jvmtiEnv, error, "Unable to deallocate notify waiters.\n");
+        if (monitor_usage.owner != NULL)
+        {
+            json jOwner;
+            if (monitorConfig.getStackTraceDepth() > 0)
+            {
+                jvmtiError err;
+                jvmtiFrameInfo frames[EventConfig::getMaxTraceDepth()];
+                jint count;
+                err = jvmtiEnv->GetStackTrace(monitor_usage.owner, 0, monitorConfig.getStackTraceDepth(), frames, &count);
+                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Stack Trace.") && count >= 1)
+                {
+                    auto jMethods = json::array();
+                    bool error = false;
+                    for (int i=0; i < count && !error; i++)
+                    {
+                        char *methodName;
+                        char *signature;
+                        err = jvmtiEnv->GetMethodName(frames[i].method, &methodName, &signature, NULL);
+                        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Name.\n"))
+                        {
+                            jclass declaring_class;
+                            err = jvmtiEnv->GetMethodDeclaringClass(frames[i].method, &declaring_class);
+                            if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class.\n"))
+                            {
+                                char *declaringClassName;
+                                err = jvmtiEnv->GetClassSignature(declaring_class, &declaringClassName, NULL);
+                                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class Signature.\n"))
+                                {
+                                    json jMethod;
+                                    jMethod["class"] = declaringClassName;
+                                    jMethod["method"] = methodName;
+                                    jMethod["signature"] = signature;
+                                    jMethods.push_back(jMethod);
+                                    err = jvmtiEnv->Deallocate((unsigned char*)declaringClassName);
+                                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate class name.\n");
+                                }
+                                else
+                                {
+                                    error = true;
+                                }
+                            }
+                            else
+                            {
+                                error = true;
+                            }
+                            err = jvmtiEnv->Deallocate((unsigned char*)methodName);
+                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate methodName.\n");
+                            err = jvmtiEnv->Deallocate((unsigned char*)signature);
+                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate method signature.\n");
+                        }
+                        else
+                        {
+                            error = true;
+                        }
+                    } /* end for loop */
+                    jOwner["stackTrace"] = jMethods;
+                }
+            }
+            /* Get the thread name */
+            jvmtiThreadInfo threadInfo;
+            error = jvmtiEnv->GetThreadInfo(monitor_usage.owner, &threadInfo);
+            if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread info."))
+            {
+                jOwner["threadName"] = threadInfo.name;
+                error = jvmtiEnv->Deallocate((unsigned char*)(threadInfo.name));
+                check_jvmti_error(jvmtiEnv, error, "Unable to deallocate thread name.\n");
+                // Local JNI refs to threadInfo.thread_group and threadInfo.context_class_loader will be freed upon return
+            }
+            /* Get Java thread ID */
+            jclass threadClass = env->FindClass("java/lang/Thread");
+            if (threadClass)
+            {
+                jmethodID getIdMethod = env->GetMethodID(threadClass, "getId", "()J");
+                if (getIdMethod)
+                {
+                    jlong tid = env->CallLongMethod(monitor_usage.owner, getIdMethod);
+                    jOwner["threadID"] = tid;
+                }
+                else
+                {
+                    printf ("Error calling GetMethodID for java/lang/Thread.getId()J\n");
+                }
+            }
+            else
+            {
+                printf ("Error calling FindClass for java/lang/Thread\n");
+            }
+            /* Get OS thread ID
+             * We need to use OpenJ9 JVMTI extension functions
+             */
+            jint extensionFunctionCount = 0;
+            jvmtiExtensionFunctionInfo *extensionFunctions = NULL;
+            jvmtiEnv->GetExtensionFunctions(&extensionFunctionCount, &extensionFunctions);
+            for (int i=0; i < extensionFunctionCount; i++) /* search for desired function */
+            {
+                jvmtiExtensionFunction function = extensionFunctions->func;
+                if (strcmp(extensionFunctions->id, COM_IBM_GET_OS_THREAD_ID) == 0)
+                {
+                    jlong threadID = 0;
+                    /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
+                    error = function(jvmtiEnv, monitor_usage.owner, &threadID);
+                    if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
+                    {
+                        jOwner["threadNativeID"] = threadID;
+                    }
+                    break;
+                }
+                extensionFunctions++; /* move on to the next extension function */    
+            }
+            j["OwnerThread"] = jOwner;
+        }
+    }
+    json jCurrent;
+    if (monitorConfig.getStackTraceDepth() > 0)
+    {
+        jvmtiError err;
+        jvmtiFrameInfo frames[EventConfig::getMaxTraceDepth()];
+        jint count;
+        err = jvmtiEnv->GetStackTrace(thread, 0, monitorConfig.getStackTraceDepth(), frames, &count);
+        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Stack Trace.") && count >= 1)
+        {
+            auto jMethods = json::array();
+            bool error = false;
+            for (int i=0; i < count && !error; i++)
+            {
+                char *methodName;
+                char *signature;
+                err = jvmtiEnv->GetMethodName(frames[i].method, &methodName, &signature, NULL);
+                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Name.\n")) 
+                {
+                    jclass declaring_class;
+                    err = jvmtiEnv->GetMethodDeclaringClass(frames[i].method, &declaring_class);
+                    if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class.\n")) 
+                    {
+                        char *declaringClassName;
+                        err = jvmtiEnv->GetClassSignature(declaring_class, &declaringClassName, NULL);
+                        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class Signature.\n")) 
+                        {
+                            json jMethod;
+                            jMethod["class"] = declaringClassName;
+                            jMethod["method"] = methodName;
+                            jMethod["signature"] = signature;
+                            jMethods.push_back(jMethod);
+                            err = jvmtiEnv->Deallocate((unsigned char*)declaringClassName);
+                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate class name.\n");
+                        }
+                        else
+                        {
+                            error = true;
+                        }
+                    }
+                    else
+                    {
+                        error = true;
+                    }
+                    err = jvmtiEnv->Deallocate((unsigned char*)methodName);
+                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate methodName.\n");
+                    err = jvmtiEnv->Deallocate((unsigned char*)signature);
+                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate method signature.\n");
+                }
+                else
+                {
+                    error = true;
+                }
+            } /* end for loop */
+            jCurrent["stackTrace"] = jMethods;
+        }
+    }
+
+    /* Get the current thread name */
+    jvmtiThreadInfo threadInfo;
+    error = jvmtiEnv->GetThreadInfo(thread, &threadInfo);
+    if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread info."))
+    {
+        jCurrent["threadName"] = threadInfo.name;
+        error = jvmtiEnv->Deallocate((unsigned char*)(threadInfo.name));
+        check_jvmti_error(jvmtiEnv, error, "Unable to deallocate thread name.\n");
+        // Local JNI refs to threadInfo.thread_group and threadInfo.context_class_loader will be freed upon return
+    }
+    /* Get Java thread ID */
+    jclass threadClass = env->FindClass("java/lang/Thread");
+    if (threadClass)
+    {
+        jmethodID getIdMethod = env->GetMethodID(threadClass, "getId", "()J");
+        if (getIdMethod)
+        {
+            jlong tid = env->CallLongMethod(thread, getIdMethod);
+            jCurrent["threadID"] = tid;
+        }
+        else
+        {
+            printf ("Error calling GetMethodID for java/lang/Thread.getId()J\n");
+        }
+    }
+    else
+    {
+        printf ("Error calling FindClass for java/lang/Thread\n");
+    }
+    /* Get OS thread ID
+     * We need to use OpenJ9 JVMTI extension functions
+     */
+    jint extensionFunctionCount = 0;
+    jvmtiExtensionFunctionInfo *extensionFunctions = NULL;
+    jvmtiEnv->GetExtensionFunctions(&extensionFunctionCount, &extensionFunctions);
+    for (int i=0; i < extensionFunctionCount; i++) /* search for desired function */
+    {
+        jvmtiExtensionFunction function = extensionFunctions->func;
+        if (strcmp(extensionFunctions->id, COM_IBM_GET_OS_THREAD_ID) == 0)
+        {
+            jlong threadID = 0;
+            /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
+            error = function(jvmtiEnv, thread, &threadID);
+            if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
+            {
+                jCurrent["threadNativeID"] = threadID;
+            }
+            break;
+        }
+        extensionFunctions++; /* move on to the next extension function */
+    }
+    j["CurrentThread"] = jCurrent;
+    sendToServer(j.dump());
+
+    /* Also call the callback */
+
+    EventConfig::CallbackIDs callbackIDs = monitorConfig.getCallBackIDs(env);
+    if (callbackIDs.cachedCallbackClass && callbackIDs.cachedCallbackMethodId)
+    {
+        jstring jsonEntry = env->NewStringUTF(j.dump().c_str());
+        if (jsonEntry)
+        {
+            env->CallStaticVoidMethod(callbackIDs.cachedCallbackClass, callbackIDs.cachedCallbackMethodId, jsonEntry);
+            /* If the callback generates an exception that is not caught
+             * suppress that exception from being propagated further
+             * because it can be confusing
+             */
+            if (env->ExceptionCheck() == JNI_TRUE)
+            {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+    }
+}

--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -142,63 +142,8 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv, JNIEnv *env, 
     /* Release the memory pinned char array */
     env->ReleaseStringUTFChars(strObj, str);
     env->DeleteLocalRef(cls);
-
+    /* Get StackTrace */
     getStackTrace(jvmtiEnv, thread, j);
-    /* if (monitorConfig.getStackTraceDepth() > 0)
-    {
-        jvmtiError err;
-        jvmtiFrameInfo frames[EventConfig::getMaxTraceDepth()];
-        jint count;
-        err = jvmtiEnv->GetStackTrace(thread, 0, monitorConfig.getStackTraceDepth(), frames, &count);
-        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Stack Trace.") && count >= 1)
-        {
-            auto jMethods = json::array();
-            bool error = false;
-            for (int i=0; i < count && !error; i++)
-            {
-                char *methodName;
-                char *signature;
-                err = jvmtiEnv->GetMethodName(frames[i].method, &methodName, &signature, NULL);
-                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Name.\n")) 
-                {
-                    jclass declaring_class;
-                    err = jvmtiEnv->GetMethodDeclaringClass(frames[i].method, &declaring_class);
-                    if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class.\n")) 
-                    {
-                        char *declaringClassName;
-                        err = jvmtiEnv->GetClassSignature(declaring_class, &declaringClassName, NULL);
-                        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class Signature.\n")) 
-                        {
-                            json jMethod;
-                            jMethod["class"] = declaringClassName;
-                            jMethod["method"] = methodName;
-                            jMethod["signature"] = signature;
-                            jMethods.push_back(jMethod);
-                            err = jvmtiEnv->Deallocate((unsigned char*)declaringClassName);
-                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate class name.\n");
-                        }
-                        else
-                        {
-                            error = true;
-                        }
-                    }
-                    else
-                    {
-                        error = true;
-                    }
-                    err = jvmtiEnv->Deallocate((unsigned char*)methodName);
-                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate methodName.\n");
-                    err = jvmtiEnv->Deallocate((unsigned char*)signature);
-                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate method signature.\n");
-                }
-                else
-                {
-                    error = true;
-                }
-            } 
-            j["stackTrace"] = jMethods;
-        }
-    }*/
     /* Get the thread name */
     jvmtiThreadInfo threadInfo;
     error = jvmtiEnv->GetThreadInfo(thread, &threadInfo);
@@ -334,63 +279,8 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
         if (monitor_usage.owner != NULL)
         {
             json jOwner;
+            /* Get StackTrace */
             getStackTrace(jvmtiEnv, monitor_usage.owner, jOwner);
-            /*
-            if (monitorConfig.getStackTraceDepth() > 0)
-            {
-                jvmtiError err;
-                jvmtiFrameInfo frames[EventConfig::getMaxTraceDepth()];
-                jint count;
-                err = jvmtiEnv->GetStackTrace(monitor_usage.owner, 0, monitorConfig.getStackTraceDepth(), frames, &count);
-                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Stack Trace.") && count >= 1)
-                {
-                    auto jMethods = json::array();
-                    bool error = false;
-                    for (int i=0; i < count && !error; i++)
-                    {
-                        char *methodName;
-                        char *signature;
-                        err = jvmtiEnv->GetMethodName(frames[i].method, &methodName, &signature, NULL);
-                        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Name.\n"))
-                        {
-                            jclass declaring_class;
-                            err = jvmtiEnv->GetMethodDeclaringClass(frames[i].method, &declaring_class);
-                            if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class.\n"))
-                            {
-                                char *declaringClassName;
-                                err = jvmtiEnv->GetClassSignature(declaring_class, &declaringClassName, NULL);
-                                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class Signature.\n"))
-                                {
-                                    json jMethod;
-                                    jMethod["class"] = declaringClassName;
-                                    jMethod["method"] = methodName;
-                                    jMethod["signature"] = signature;
-                                    jMethods.push_back(jMethod);
-                                    err = jvmtiEnv->Deallocate((unsigned char*)declaringClassName);
-                                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate class name.\n");
-                                }
-                                else
-                                {
-                                    error = true;
-                                }
-                            }
-                            else
-                            {
-                                error = true;
-                            }
-                            err = jvmtiEnv->Deallocate((unsigned char*)methodName);
-                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate methodName.\n");
-                            err = jvmtiEnv->Deallocate((unsigned char*)signature);
-                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate method signature.\n");
-                        }
-                        else
-                        {
-                            error = true;
-                        }
-                    } 
-                    jOwner["stackTrace"] = jMethods;
-                }
-            }*/
             /* Get the thread name */
             jvmtiThreadInfo threadInfo;
             error = jvmtiEnv->GetThreadInfo(monitor_usage.owner, &threadInfo);
@@ -446,64 +336,8 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
         }
     }
     json jCurrent;
+    /* Get StackTrace */
     getStackTrace(jvmtiEnv, thread, jCurrent);
-    /*
-    if (monitorConfig.getStackTraceDepth() > 0)
-    {
-        jvmtiError err;
-        jvmtiFrameInfo frames[EventConfig::getMaxTraceDepth()];
-        jint count;
-        err = jvmtiEnv->GetStackTrace(thread, 0, monitorConfig.getStackTraceDepth(), frames, &count);
-        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Stack Trace.") && count >= 1)
-        {
-            auto jMethods = json::array();
-            bool error = false;
-            for (int i=0; i < count && !error; i++)
-            {
-                char *methodName;
-                char *signature;
-                err = jvmtiEnv->GetMethodName(frames[i].method, &methodName, &signature, NULL);
-                if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Name.\n")) 
-                {
-                    jclass declaring_class;
-                    err = jvmtiEnv->GetMethodDeclaringClass(frames[i].method, &declaring_class);
-                    if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class.\n")) 
-                    {
-                        char *declaringClassName;
-                        err = jvmtiEnv->GetClassSignature(declaring_class, &declaringClassName, NULL);
-                        if (check_jvmti_error(jvmtiEnv, err, "Unable to retrieve Method Declaring Class Signature.\n")) 
-                        {
-                            json jMethod;
-                            jMethod["class"] = declaringClassName;
-                            jMethod["method"] = methodName;
-                            jMethod["signature"] = signature;
-                            jMethods.push_back(jMethod);
-                            err = jvmtiEnv->Deallocate((unsigned char*)declaringClassName);
-                            check_jvmti_error(jvmtiEnv, err, "Unable to deallocate class name.\n");
-                        }
-                        else
-                        {
-                            error = true;
-                        }
-                    }
-                    else
-                    {
-                        error = true;
-                    }
-                    err = jvmtiEnv->Deallocate((unsigned char*)methodName);
-                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate methodName.\n");
-                    err = jvmtiEnv->Deallocate((unsigned char*)signature);
-                    check_jvmti_error(jvmtiEnv, err, "Unable to deallocate method signature.\n");
-                }
-                else
-                {
-                    error = true;
-                }
-            } 
-            jCurrent["stackTrace"] = jMethods;
-        }
-    }*/
-
     /* Get the current thread name */
     jvmtiThreadInfo threadInfo;
     error = jvmtiEnv->GetThreadInfo(thread, &threadInfo);


### PR DESCRIPTION
Prints the current and owner thread details i.e threadname
threadId and nativethreadId in MonitorContendedEnter Event

Fixes: #20
Fixes: #38
Signed-off-by: Ravali Yatham <rayatha1@in.ibm.com>