### PR TITLE
doc: add new verbose option to the agent on start-up commands.

### DIFF
--- a/perf-tool/README.md
+++ b/perf-tool/README.md
@@ -35,6 +35,7 @@ These commands are passed to the agent on start up. The format of the commands s
 | commandFile | Path to file | Provide the agent with a path to a file containing commands (see [Function Commands](#function-commands)) that will be fed to the agent in headless mode |
 | logFile | Path to file | Provide the agent with a location to place a log file for agent output. The agent will create a new file if it does not exist. |
 | portNo | Port Number | Provide the agent with a port to start the server on. The default port is 9002.  
+| verbose | 1,2,3 | Provide the agent with a degree of verbosity to show the additional information. |
 
 
 # Function Commands


### PR DESCRIPTION
fixes: https://github.com/eclipse/openj9-utils/issues/36
Signed-off-by: PoojaDurgad <Pooja.D.P@ibm.com>