### PR TITLE
Implement JLM support in the perf agent

### DIFF
--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -183,6 +183,8 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM* vm, char *options, void *reserved)
             return rc;
         }
 
+        ExtensionFunctions::getExtensionFunctions(jvmti);
+
         error = setCallbacks(jvmti);
         if (error != JVMTI_ERROR_NONE)
             return JNI_ERR; /* without callbacks I cannot do anything */
@@ -219,6 +221,8 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
         printf("Unable to get access to JVMTI version 1.2");
         return JNI_ERR;
     }
+
+    ExtensionFunctions::getExtensionFunctions(jvmti);
 
     jvmtiError error = setCallbacks(jvmti);
     if (error != JVMTI_ERROR_NONE)

--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -153,24 +153,15 @@ JNIEXPORT void JNICALL MonitorContendedEntered(jvmtiEnv *jvmtiEnv, JNIEnv *env, 
     /* Get OS thread ID 
      * We need to use OpenJ9 JVMTI extension functions
      */
-    jint extensionFunctionCount = 0;
-    jvmtiExtensionFunctionInfo *extensionFunctions = NULL;
-    jvmtiEnv->GetExtensionFunctions(&extensionFunctionCount, &extensionFunctions);
-    for (int i=0; i < extensionFunctionCount; i++) /* search for desired function */
+    if (ExtensionFunctions::_osThreadID)
     {
-        jvmtiExtensionFunction function = extensionFunctions->func;
-        if (strcmp(extensionFunctions->id, COM_IBM_GET_OS_THREAD_ID) == 0)
+        jlong threadID = 0;
+        /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
+        error = (ExtensionFunctions::_osThreadID)(jvmtiEnv, thread, &threadID);
+        if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
         {
-            jlong threadID = 0;
-            /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
-            error = function(jvmtiEnv, thread, &threadID);
-            if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
-            {
-                j["threadNativeID"] = threadID;
-            }
-            break;
+            j["threadNativeID"] = threadID;
         }
-        extensionFunctions++; /* move on to the next extension function */
     }
     
     sendToServer(j.dump());
@@ -322,24 +313,15 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
             /* Get OS thread ID
              * We need to use OpenJ9 JVMTI extension functions
              */
-            jint extensionFunctionCount = 0;
-            jvmtiExtensionFunctionInfo *extensionFunctions = NULL;
-            jvmtiEnv->GetExtensionFunctions(&extensionFunctionCount, &extensionFunctions);
-            for (int i=0; i < extensionFunctionCount; i++) /* search for desired function */
+            if (ExtensionFunctions::_osThreadID)
             {
-                jvmtiExtensionFunction function = extensionFunctions->func;
-                if (strcmp(extensionFunctions->id, COM_IBM_GET_OS_THREAD_ID) == 0)
+                jlong threadID = 0;
+                /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
+                error = (ExtensionFunctions::_osThreadID)(jvmtiEnv, monitor_usage.owner, &threadID);
+                if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
                 {
-                    jlong threadID = 0;
-                    /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
-                    error = function(jvmtiEnv, monitor_usage.owner, &threadID);
-                    if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
-                    {
-                        jOwner["threadNativeID"] = threadID;
-                    }
-                    break;
+                    jOwner["threadNativeID"] = threadID;
                 }
-                extensionFunctions++; /* move on to the next extension function */    
             }
             j["OwnerThread"] = jOwner;
         }
@@ -379,24 +361,15 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
     /* Get OS thread ID
      * We need to use OpenJ9 JVMTI extension functions
      */
-    jint extensionFunctionCount = 0;
-    jvmtiExtensionFunctionInfo *extensionFunctions = NULL;
-    jvmtiEnv->GetExtensionFunctions(&extensionFunctionCount, &extensionFunctions);
-    for (int i=0; i < extensionFunctionCount; i++) /* search for desired function */
+    if (ExtensionFunctions::_osThreadID)
     {
-        jvmtiExtensionFunction function = extensionFunctions->func;
-        if (strcmp(extensionFunctions->id, COM_IBM_GET_OS_THREAD_ID) == 0)
+        jlong threadID = 0;
+        /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
+        error = (ExtensionFunctions::_osThreadID)(jvmtiEnv, thread, &threadID);
+        if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
         {
-            jlong threadID = 0;
-            /* jvmtiError GetOSThreadID(jvmtiEnv* jvmti_env, jthread thread, jlong * threadid_ptr); */
-            error = function(jvmtiEnv, thread, &threadID);
-            if (check_jvmti_error(jvmtiEnv, error, "Unable to retrieve thread ID."))
-            {
-                jCurrent["threadNativeID"] = threadID;
-            }
-            break;
+            jCurrent["threadNativeID"] = threadID;
         }
-        extensionFunctions++; /* move on to the next extension function */
     }
     j["CurrentThread"] = jCurrent;
     sendToServer(j.dump());


### PR DESCRIPTION
This commit adds JLM (Java Lock Monitor) support to the
OpenJ9 Perf Agent. The new command must look like this:
{
    "command": "start",
    "delay": 1,
    "functionality": "jlm"
}
At the moment, the only option that could be sent with this
command is the "delay". All other keywords will be ignored.
Typically, the user sends a "start" command for the "jlm"
functionality and, after a while (specified by the delay),
sends a "stop" command. E.g.:
{
    "command": "stop",
    "delay": 10,
    "functionality": "jlm"
}
Once the stop command is received, the agent will ask the JVM
to send a JLM dump which contains information about all the
monitors in the JVM. The agent parses that dump and creates
a more readable output encoded as json. In this output, the
monitors that were not acquired at least once will be skipped.
The monitors are grouped by their type: Java monitors and
Raw monitors (aka system monitors).
Example of output:
```
{
  "body": {
    "JLM size": 24881,
    "javaMonitors": [
      {
        "enterCount": 142780,
        "holdTime": 34360262656,
        "monitorName": "[00007F8E640024A8] Work@00000007FFF77000 (Object)",
        "recursiveCount": 0,
        "slowCount": 1002,
        "spinCount": 51723505,
        "tag": 0,
        "yieldCount": 1560634
      }
    ],
    "rawMonitors": [
      {
        "enterCount": 1,
        "holdTime": 0,
        "monitorName": "[00007F8ED001A598] GCExtensions::_lightweightNonReentrantLockPoolMutex",
        "recursiveCount": 0,
        "slowCount": 0,
        "spinCount": 0,
        "tag": 0,
        "yieldCount": 0
      },
      {
        "enterCount": 4,
        "holdTime": 0,
        "monitorName": "[00007F8ED001B828] JIT-SmallBlockListsMonitor",
        "recursiveCount": 0,
        "slowCount": 0,
        "spinCount": 0,
        "tag": 0,
        "yieldCount": 0
      },
...
      {
        "enterCount": 1,
        "holdTime": 0,
        "monitorName": "[00007F8ED00A1B10] MM_MemorySubSpace:_lock",
        "recursiveCount": 0,
        "slowCount": 0,
        "spinCount": 0,
        "tag": 0,
        "yieldCount": 0
      }
    ]
  },
```
This commit also factors out the code that determines the IBM JVMTI
extensions, so that we call that code only once, reducing overhead.

Closes: #24

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>