### PR TITLE
Fix MethodEnter support for Perf Agent

### DIFF
--- a/perf-tool/include/methodEntry.hpp
+++ b/perf-tool/include/methodEntry.hpp
@@ -30,6 +30,4 @@ JNIEXPORT void JNICALL MethodEntry(jvmtiEnv *jvmtiEnv,
             jthread thread,
             jmethodID method);
 
-void setMethodEntrySampleRate(int rate);
-
 #endif /* METHODENTRY_H_ */

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -228,6 +228,12 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
     if (error != JVMTI_ERROR_NONE)
         return JNI_ERR;
 
+    jvmtiCapabilities capa;
+    memset(&capa, 0, sizeof(jvmtiCapabilities));
+    capa.can_generate_method_entry_events = 1; /* this one can only be added during the load phase */
+    error = jvmti->AddCapabilities(&capa);
+    check_jvmti_error(jvmti, error, "Unable to init MethodEnter capability.");
+
     error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, (jthread)NULL);
     check_jvmti_error(jvmti, error, "Unable to init VM init event.");
 

--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -375,7 +375,7 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
         }
     }
     j["CurrentThread"] = jCurrent;
-    sendToServer(j.dump());
+    sendToServer(j.dump(), "MonitorContendedEnter");
 
     /* Also call the callback */
 


### PR DESCRIPTION
In order to enable method tracing we need to set the
`can_generate_method_entry_events` capability. For some
reason this capability can be enabled only during the
OnLoad phase. Therefore, the agent must be loaded from
the very beginning, and late attach will not do.

This commit also adds the ability to print the stack trace
up to the specified depth.

Examples of commands:
```
  {
    "functionality": "methodEntryEvents",
    "command": "start",
    "delay": 1,
    "stackTraceDepth": 5
  },
  {
    "functionality": "methodEntryEvents",
    "command": "stop",
    "delay": 5
  }
```

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>