### PR TITLE
fix event-type in monitorContendedEnter

### DIFF
--- a/perf-tool/src/monitor.cpp
+++ b/perf-tool/src/monitor.cpp
@@ -326,9 +326,6 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
             j["OwnerThread"] = jOwner;
         }
     }
-
-    sendToServer(j.dump(), "monitorContendedEnterEvent");
-
     json jCurrent;
     /* Get StackTrace */
     monitorConfig.getStackTrace(jvmtiEnv, thread, jCurrent, stackTraceDepth);
@@ -375,7 +372,7 @@ JNIEXPORT void JNICALL MonitorContendedEnter(jvmtiEnv *jvmtiEnv, JNIEnv *env, jt
         }
     }
     j["CurrentThread"] = jCurrent;
-    sendToServer(j.dump(), "MonitorContendedEnter");
+    sendToServer(j.dump(), "MonitorContendedEnterEvent");
 
     /* Also call the callback */
 


### PR DESCRIPTION
In monitorContendedEnter we are sending data
to server twice after getting owner thread info
and current thread info. Fixed that by removing
one after Owner info

Signed-Off-by: Ravali Yatham <rayatha1@in.ibm.com>