### PR TITLE
Implement methodExit event in perf agent

### DIFF
--- a/perf-tool/include/methodEntry.hpp
+++ b/perf-tool/include/methodEntry.hpp
@@ -26,8 +26,13 @@
 #include <jvmti.h>
 
 JNIEXPORT void JNICALL MethodEntry(jvmtiEnv *jvmtiEnv,
-            JNIEnv* env,
-            jthread thread,
-            jmethodID method);
-
+                                   JNIEnv* env,
+                                   jthread thread,
+                                   jmethodID method);
+JNIEXPORT void JNICALL MethodExit(jvmtiEnv *jvmtiEnv,
+                                  JNIEnv* env,
+                                  jthread thread,
+                                  jmethodID method,
+                                  jboolean was_popped_by_exception,
+                                  jvalue return_value);
 #endif /* METHODENTRY_H_ */

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -148,6 +148,7 @@ jvmtiError setCallbacks(jvmtiEnv *jvmti)
     callbacks.MonitorContendedEnter = &MonitorContendedEnter;
     callbacks.MonitorContendedEntered = &MonitorContendedEntered;
     callbacks.MethodEntry = &MethodEntry;
+    callbacks.MethodExit = &MethodExit;
     callbacks.Exception = &Exception;
     jvmtiError error = jvmti->SetEventCallbacks(&callbacks, (jint)sizeof(callbacks));
     check_jvmti_error(jvmti, error, "Cannot set jvmti callbacks.");
@@ -231,6 +232,7 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
     jvmtiCapabilities capa;
     memset(&capa, 0, sizeof(jvmtiCapabilities));
     capa.can_generate_method_entry_events = 1; /* this one can only be added during the load phase */
+    capa.can_generate_method_exit_events = 1;
     error = jvmti->AddCapabilities(&capa);
     check_jvmti_error(jvmti, error, "Unable to init MethodEnter capability.");
 


### PR DESCRIPTION
This event is very much similar to the MethodEnter event.
Example of commands to enable/disable:
```
  {
    "functionality": "methodExitEvents",
    "command": "start",
    "delay": 1,
    "stackTraceDepth": 3
  },
  {
    "functionality": "methodExitEvents",
    "command": "stop",
    "delay": 3
  }
```
Example of output:
```
{
  "body": {
    "methodClass": "Ljava/lang/String;",
    "methodName": "lengthInternal",
    "methodNum": 5908,
    "methodSig": "()I",
    "stackTrace": [
      {
        "class": "Ljava/lang/String;",
        "method": "lengthInternal",
        "signature": "()I"
      },
      {
        "class": "Ljava/lang/String;",
        "method": "length",
        "signature": "()I"
      },
      {
        "class": "Ljava/lang/String;",
        "method": "indexOf",
        "signature": "(Ljava/lang/String;I)I"
      }
    ]
  },
  "eventType": "methodExitEvent",
  "from": "Server",
  "timestamp": 1616194905999605293
},
```

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>