### PR TITLE
Compute lockLatency

### DIFF
--- a/perf-tool/src/agentOptions.cpp
+++ b/perf-tool/src/agentOptions.cpp
@@ -96,10 +96,10 @@ void modifyMonitorEvents(const std::string& function, const std::string& command
         }
         error = jvmti->AddCapabilities(&capa);
         check_jvmti_error(jvmti, error, "Unable to init Monitor Events capability.");
-        error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
-        check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEntered event notifications.");
         error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, (jthread)NULL);
         check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEnter event notifications.");
+        error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
+        check_jvmti_error(jvmti, error, "Unable to enable MonitorContendedEntered event notifications.");
     }
     else if (!command.compare("stop"))
     {
@@ -114,10 +114,10 @@ void modifyMonitorEvents(const std::string& function, const std::string& command
         capa.can_get_monitor_info = 1;
         error = jvmti->RelinquishCapabilities(&capa);
         check_jvmti_error(jvmti, error, "Unable to relinquish Monitor Events Capability.");
-        error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
-        check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEntered event.");
         error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, (jthread)NULL);
         check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEnter event.");
+        error = jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, (jthread)NULL);
+        check_jvmti_error(jvmti, error, "Unable to disable MonitorContendedEntered event.");
     } 
     else 
     {


### PR DESCRIPTION
Calculates how much time thread waited
to acquire the monitor

Signed-off-by: Ravali Yatham <rayatha1@in.ibm.com>