### PR TITLE
perf-tool: fix process crashes.

### DIFF
--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -122,11 +122,10 @@ void parseAgentOptions(const char *options)
             }
         }
     }
-
 //check if commandspath exists or not
 FILE *file;
 file = fopen(commandsPath.c_str() ,"r");
-if(file == NULL)
+if (file == NULL)
 {
     fprintf(stderr, "commandspath: %s doesn't exist\n",commandsPath.c_str());
     exit(0);

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -123,6 +123,16 @@ void parseAgentOptions(const char *options)
         }
     }
 
+//check if commandspath exists or not
+FILE *file;
+file = fopen(commandsPath.c_str() ,"r");
+if(file == NULL)
+{
+    fprintf(stderr, "commandspath doesn't exist\n");
+    exit(0);
+}
+fclose(file);
+
     if (verbose != ERROR && verbose != WARN && verbose != INFO)
     {
         verbose = NONE;

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -128,7 +128,7 @@ FILE *file;
 file = fopen(commandsPath.c_str() ,"r");
 if(file == NULL)
 {
-    fprintf(stderr, "commandspath doesn't exist\n");
+    fprintf(stderr, "commandspath: %s doesn't exist\n",commandsPath.c_str());
     exit(0);
 }
 fclose(file);

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -122,15 +122,15 @@ void parseAgentOptions(const char *options)
             }
         }
     }
-//check if commandspath exists or not
-FILE *file;
-file = fopen(commandsPath.c_str() ,"r");
-if (file == NULL)
-{
-    fprintf(stderr, "commandspath: %s doesn't exist\n",commandsPath.c_str());
-    exit(0);
-}
-fclose(file);
+    //check if commandspath exists or not
+    FILE *file;
+    file = fopen(commandsPath.c_str() ,"r");
+    if (file == NULL)
+    {
+        fprintf(stderr, "commandspath: %s doesn't exist\n",commandsPath.c_str());
+        exit(0);
+    }
+    fclose(file);
 
     if (verbose != ERROR && verbose != WARN && verbose != INFO)
     {


### PR DESCRIPTION
avoid process crashes for non-existent command file.
fixes: https://github.com/eclipse/openj9-utils/issues/33

Signed-off-by: PoojaDurgad <Pooja.D.P@ibm.com>