### PR TITLE
Add filtering capability to methodEnter/Exit events

### DIFF
--- a/perf-tool/include/infra.hpp
+++ b/perf-tool/include/infra.hpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <jvmti.h>
 #include "json.hpp"
@@ -76,6 +77,12 @@ public:
 private:
     int sampleRate = 1;
     int stackTraceDepth = 0;
+    bool methodFilter = false;
+    bool signatureFilter = false;
+    bool classFilter = false;
+    std::regex methodRegex;
+    std::regex signatureRegex;
+    std::regex classRegex; 
     std::string callbackClass;
     std::string callbackMethod;
     std::string callbackSignature;
@@ -92,6 +99,8 @@ public:
     const std::string& getCallbackMethod() const { return callbackMethod; }
     const std::string &getCallbackSignature() const { return callbackSignature; }
     void setCallbacks(const std::string& cls, const std::string& method, const std::string& sig);
+    void setFilter(const std::string& cls, const std::string& method, const std::string& sig);
+    std::tuple<bool, bool, bool, std::regex, std::regex, std::regex> getFilter();
     void getStackTrace(jvmtiEnv *jvmtiEnv, jthread thread, json& j, jint StackTraceDepth);
     jclass getCachedCallbackClass() const { return callbackIDs.cachedCallbackClass; }
     jmethodID getCachedCallbackMethodId() const { return callbackIDs.cachedCallbackMethodId; }

--- a/perf-tool/src/agentOptions.cpp
+++ b/perf-tool/src/agentOptions.cpp
@@ -189,7 +189,8 @@ void modifyObjectAllocEvents(const std::string& function,const std::string& comm
 }
 
 
-void modifyMethodEntryEvents(const std::string& function, const std::string& command, int rate, int stackTraceDepth)
+void modifyMethodEntryEvents(const std::string& function, const std::string& command, int rate, int stackTraceDepth,
+                             const std::string& classFilter, const std::string& methodFilter, const std::string& signatureFilter)
 {
     jvmtiError error;
     methodEnterConfig.setSampleRate(rate);
@@ -203,6 +204,7 @@ void modifyMethodEntryEvents(const std::string& function, const std::string& com
     }
     else if (!command.compare("start"))
     { 
+        methodEnterConfig.setFilter(classFilter, methodFilter, signatureFilter);
         if (verbose >= Verbose::INFO)
             printf("Processing MethodEnter start command\n");
         error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, (jthread)NULL);
@@ -214,7 +216,8 @@ void modifyMethodEntryEvents(const std::string& function, const std::string& com
     }
 }
 
-void modifyMethodExitEvents(const std::string& function, const std::string& command, int rate, int stackTraceDepth)
+void modifyMethodExitEvents(const std::string& function, const std::string& command, int rate, int stackTraceDepth,
+                            const std::string& classFilter, const std::string& methodFilter, const std::string& signatureFilter)
 {
     jvmtiError error;
     methodExitConfig.setSampleRate(rate);
@@ -228,6 +231,7 @@ void modifyMethodExitEvents(const std::string& function, const std::string& comm
     }
     else if (!command.compare("start"))
     { 
+        methodExitConfig.setFilter(classFilter, methodFilter, signatureFilter);
         if (verbose >= Verbose::INFO)
             printf("Processing MethodExit start command\n");
         error = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, (jthread)NULL);
@@ -440,11 +444,27 @@ void agentCommand(const json& jCommand)
         }
         else if (!function.compare("methodEntryEvents"))
         {
-            modifyMethodEntryEvents(function, command, sampleRate, stackTraceDepth);
+            std::string classFilter, methodFilter, signatureFilter;
+            if (jCommand.contains("filter"))
+            {
+                auto jfilter = jCommand["filter"];
+                classFilter = jfilter["class"].get<std::string>();
+                methodFilter = jfilter["method"].get<std::string>();
+                signatureFilter = jfilter["signature"].get<std::string>();
+            }
+            modifyMethodEntryEvents(function, command, sampleRate, stackTraceDepth, classFilter, methodFilter, signatureFilter);
         }
        else if (!function.compare("methodExitEvents"))
         {
-            modifyMethodExitEvents(function, command, sampleRate, stackTraceDepth);
+            std::string classFilter, methodFilter, signatureFilter;
+            if (jCommand.contains("filter"))
+            {
+                auto jfilter = jCommand["filter"];
+                classFilter = jfilter["class"].get<std::string>();
+                methodFilter = jfilter["method"].get<std::string>();
+                signatureFilter = jfilter["signature"].get<std::string>();
+            }
+            modifyMethodExitEvents(function, command, sampleRate, stackTraceDepth, classFilter, methodFilter, signatureFilter);
         }
         else if (!function.compare("exceptionEvents"))
         {

--- a/perf-tool/src/infra.cpp
+++ b/perf-tool/src/infra.cpp
@@ -126,6 +126,24 @@ void EventConfig::setCallbacks(const std::string& cls, const std::string& method
     callbackIDs.cachedCallbackMethodId = NULL;
 }
 
+void EventConfig::setFilter(const std::string& cls, const std::string& method, const std::string& sig)
+{
+    std::lock_guard<std::mutex> lg(configMutex);
+    classFilter = !cls.empty();
+    classRegex.assign(cls);
+    methodFilter = !method.empty();
+    methodRegex.assign(method);
+    signatureFilter = !sig.empty();
+    signatureRegex.assign(sig);
+}
+
+std::tuple<bool, bool, bool, std::regex, std::regex, std::regex> EventConfig::getFilter()
+{
+    std::lock_guard<std::mutex> lg(configMutex);
+    return { classFilter, methodFilter, signatureFilter, classRegex, methodRegex, signatureRegex };
+}
+
+
 EventConfig::CallbackIDs EventConfig::getCallBackIDs(JNIEnv *env)
 {
     std::lock_guard<std::mutex> lg(configMutex);


### PR DESCRIPTION
Since methodEnter/Exit hooks can generate very many events
it may usefull to have some way of requesting such events
only for some classes/methods. This commit implements such
a filtering scheme.
Syntax of a command:
  {
    "functionality": "methodEntryEvents",
    "command": "start",
    "delay": 0,
    "stackTraceDepth": 3,
    "filter": {
       "class": "LMyThread;",
       "method": "syncRegion",
       "signature": "\\(I\\)"
    }

The matching for the "filter" class, method name and signature is
done using ECMAScript grammar: http://www.cplusplus.com/reference/regex/ECMAScript
Note that parenthesis must be escaped twice (using \\): once for
the JSON and one for regular expressions inside C++ code.
Square brackets and dollar sign which are typical used in Java class naming
also needs to be escaped.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>