### PR TITLE
fix process crashes in interactive and headless mode.

### DIFF
--- a/perf-tool/include/serverClients.hpp
+++ b/perf-tool/include/serverClients.hpp
@@ -74,7 +74,7 @@ protected:
 public:
 private:
     int currentInterval = ServerConstants::COMMAND_INTERVALS;
-    std::ifstream commandsFile;
+    FILE * commandsFile;
     json commands;
 
     /*

--- a/perf-tool/src/agent.cpp
+++ b/perf-tool/src/agent.cpp
@@ -122,15 +122,6 @@ void parseAgentOptions(const char *options)
             }
         }
     }
-    //check if commandspath exists or not
-    FILE *file;
-    file = fopen(commandsPath.c_str() ,"r");
-    if (file == NULL)
-    {
-        fprintf(stderr, "commandspath: %s doesn't exist\n",commandsPath.c_str());
-        exit(0);
-    }
-    fclose(file);
 
     if (verbose != ERROR && verbose != WARN && verbose != INFO)
     {

--- a/perf-tool/src/serverClients.cpp
+++ b/perf-tool/src/serverClients.cpp
@@ -121,12 +121,11 @@ void LoggingClient::logData(const string message, std::string event, const std::
 
 CommandClient::CommandClient(const string filename)
 {
-    commandsFile.open(filename);
-    if (!commandsFile.is_open())
+    commandsFile = fopen(filename.c_str() ,"r");
+    if (commandsFile == NULL)
     {
-        if (verbose >= ERROR)
-            printf("filename: %s\n", filename.c_str());
-        perror("ERROR opening commands file");
+        fprintf(stderr, "commands file %s doesn't exists\n", filename.c_str());
+        exit(0);
     }
     try
     {
@@ -141,9 +140,9 @@ CommandClient::CommandClient(const string filename)
 
 void CommandClient::closeFile(void)
 {
-    if (commandsFile.is_open())
+    if (commandsFile)
     {
-        commandsFile.close();
+        fclose(commandsFile);
     }
 }
 


### PR DESCRIPTION
fix process crash for non existent command file in headless mode and commands in interactive mode.
fixes: https://github.com/eclipse/openj9-utils/issues/33
Signed-off-by: PoojaDurgad <Pooja.D.P@ibm.com>