### PR TITLE
Avoid using streams

### DIFF
--- a/perf-tool/include/serverClients.hpp
+++ b/perf-tool/include/serverClients.hpp
@@ -24,7 +24,6 @@
 #define SERVERCLIENTS_H_
 
 #include <string>
-#include <fstream>
 #include <unistd.h>
 
 #include "json.hpp"
@@ -99,7 +98,7 @@ class LoggingClient
 protected:
 public:
 private:
-    std::ofstream logFile;
+    FILE * logFile;
 
     /*
      * Function members


### PR DESCRIPTION
While logging data to logFile use traditional
C FILE operations instead of streams

Signed-off-by: Ravali Yatham <rayatha1@in.ibm.com>