### PR TITLE
Update JITServer helm chart to OpenJ9 0.29.0

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,18 +23,48 @@ apiVersion: v1
 entries:
   openj9-jitserver-chart:
   - apiVersion: v2
-    appVersion: 0.27.0
-    created: "2021-08-17T20:37:10.271808346-04:00"
+    appVersion: 0.29.0
+    created: "2021-10-28T19:09:38.426933784-04:00"
     description: |-
       Eclipse OpenJ9 JITServer Helm Chart.
-      
+
       License
-      
+
       This chart is made available under the terms of the Eclipse Public License 2.0
       which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
       or the Apache License, Version 2.0 which accompanies this distribution and
       is available at https://www.apache.org/licenses/LICENSE-2.0.
-      
+
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: a35bcd545ce8aad93f9788f2ec283a1ae66184549e6f912213a716373fab2503
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/eclipse-openj9/openj9-utils/files/7437792/openj9-jitserver-chart-0.29.0.tar.gz/openj9-jitserver-chart-0.29.0.tar.gz
+    version: 0.29.0
+  - apiVersion: v2
+    appVersion: 0.27.0
+    created: "2021-08-17T20:37:10.271808346-04:00"
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart.
+
+      License
+
+      This chart is made available under the terms of the Eclipse Public License 2.0
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+      or the Apache License, Version 2.0 which accompanies this distribution and
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+
       The JDK binaries installed by this chart are licensed under the GPLv2+CE.
     digest: c4b2e28107027178ff22ed67eaae8cdbf3eed03f6f102902466b2c1d339b859f
     icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
@@ -55,7 +85,7 @@ entries:
   - apiVersion: v2
     appVersion: 0.26.0
     created: "2021-06-30T07:24:42.674365859-07:00"
-    description: |- 
+    description: |-
       Eclipse OpenJ9 JITServer Helm Chart.
 
       License
@@ -112,4 +142,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2021-08-17T20:37:10.270884019-04:00"
+generated: "2021-10-28T19:09:38.426031495-04:00"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -23,13 +23,13 @@
 apiVersion: v2
 name: openj9-jitserver-chart
 description: |-
-  Eclipse OpenJ9 JITServer Helm Chart. 
+  Eclipse OpenJ9 JITServer Helm Chart.
 
   License
 
-  This chart is made available under the terms of the Eclipse Public License 2.0 
-  which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ 
-  or the Apache License, Version 2.0 which accompanies this distribution and 
+  This chart is made available under the terms of the Eclipse Public License 2.0
+  which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
   is available at https://www.apache.org/licenses/LICENSE-2.0.
 
   The JDK binaries installed by this chart are licensed under the GPLv2+CE.
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.27.0
-appVersion: 0.27.0
+version: 0.29.0
+appVersion: 0.29.0
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -23,8 +23,8 @@
 replicaCount: 1
 
 image:
-  repository: adoptopenjdk/openjdk8-openj9 
-  tag: jre8u302-b08_openj9-0.27.0
+  repository: ibm-semeru-runtimes
+  tag: open-8u312-b07-jre
   pullPolicy: IfNotPresent
 
 env:
@@ -47,7 +47,7 @@ serviceAccount:
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: 
+securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
@@ -76,11 +76,11 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: 
+affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions: 
+      - matchExpressions:
         - key: beta.kubernetes.io/arch
           operator: In
           values:


### PR DESCRIPTION

[openj9-jitserver-chart-0.29.0.tar.gz](https://github.com/eclipse-openj9/openj9-utils/files/7437792/openj9-jitserver-chart-0.29.0.tar.gz)


Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>